### PR TITLE
feat(docs): add swagger documentation for users module

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/mapped-types": "^2.1.0",
         "@nestjs/passport": "^11.0.5",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.1.0",
         "@nestjs/typeorm": "^11.0.0",
         "bcrypt": "^5.1.1",
         "class-transformer": "^0.5.1",
@@ -1959,6 +1960,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==",
+      "license": "MIT"
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@napi-rs/nice/-/nice-1.0.1.tgz",
@@ -2558,6 +2565,39 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.1.0.tgz",
+      "integrity": "sha512-+GQ+q1ASTBvGi0DYHukWi8NVVVLszedwLLqHdLRnJh8rjokt8YTDb7roImvT/YMmYgPvaWBv/4JYdZH4FueLPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.20.1"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/testing": {
       "version": "11.0.12",
       "resolved": "https://registry.npmjs.org/@nestjs/testing/-/testing-11.0.12.tgz",
@@ -2675,6 +2715,13 @@
       "funding": {
         "url": "https://opencollective.com/unts"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4230,7 +4277,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -8194,7 +8240,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -10899,6 +10944,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.20.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.20.1.tgz",
+      "integrity": "sha512-qBPCis2w8nP4US7SvUxdJD3OwKcqiWeZmjN2VWhq2v+ESZEXOP/7n4DeiOiiZcGYTKMHAHUUrroHaTsjUWTEGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@nestjs/mapped-types": "^2.1.0",
     "@nestjs/passport": "^11.0.5",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.1.0",
     "@nestjs/typeorm": "^11.0.0",
     "bcrypt": "^5.1.1",
     "class-transformer": "^0.5.1",

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,30 @@
 import { NestFactory } from '@nestjs/core';
+import { NestExpressApplication } from '@nestjs/platform-express';
 import { AppModule } from './app.module';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
+import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  app.enable('trust proxy');
+  app.enableCors();
+  app.setGlobalPrefix('api', {
+    exclude: ['/', 'health', 'api', 'api/docs', 'probe'],
+  });
+  app.useGlobalPipes(new ValidationPipe());
+
+  const config = new DocumentBuilder()
+    .setTitle('IceProject API Documentation')
+    .setDescription('API documentation for IceProject (POS/ERP system)')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api/docs', app, document);
+
   await app.listen(process.env.PORT ?? 3000);
 }
-bootstrap();
+bootstrap().catch((err) => {
+  console.error('Failed to start application:', err);
+  process.exit(1);
+});

--- a/src/modules/users/docs/create-user.docs.ts
+++ b/src/modules/users/docs/create-user.docs.ts
@@ -1,0 +1,23 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiBadRequestResponse,
+} from '@nestjs/swagger';
+import { ApiResponse as ApiResponseType } from '../types/response.type';
+import { User } from '../entities/user.entity';
+
+export const CreateUserDocs = {
+  create: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Create a new user' }),
+      ApiResponse({
+        status: 201,
+        description: 'User created successfully',
+        type: () => ApiResponseType<User>,
+      }),
+      ApiBadRequestResponse({
+        description: 'Bad Request - Invalid or missing data',
+      }),
+    ),
+};

--- a/src/modules/users/docs/delete-user-by-id.docs.ts
+++ b/src/modules/users/docs/delete-user-by-id.docs.ts
@@ -1,0 +1,22 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import { ApiResponse as ApiResponseType } from '../types/response.type';
+
+export const DeleteUserByIdDocs = {
+  delete: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Delete a user by ID' }),
+      ApiResponse({
+        status: 200,
+        description: 'User deleted successfully',
+        type: () => ApiResponseType<boolean>,
+      }),
+      ApiNotFoundResponse({
+        description: 'User not found',
+      }),
+    ),
+};

--- a/src/modules/users/docs/get-all-users.docs.ts
+++ b/src/modules/users/docs/get-all-users.docs.ts
@@ -1,0 +1,16 @@
+import { applyDecorators } from '@nestjs/common';
+import { ApiOperation, ApiResponse } from '@nestjs/swagger';
+import { ApiResponse as ApiResponseType } from '../types/response.type';
+import { User } from '../entities/user.entity';
+
+export const GetAllUsersDocs = {
+  get: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Get all users' }),
+      ApiResponse({
+        status: 200,
+        description: 'Users retrieved successfully',
+        type: () => ApiResponseType<User[]>,
+      }),
+    ),
+};

--- a/src/modules/users/docs/get-user-by-id.docs.ts
+++ b/src/modules/users/docs/get-user-by-id.docs.ts
@@ -1,0 +1,23 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiNotFoundResponse,
+} from '@nestjs/swagger';
+import { ApiResponse as ApiResponseType } from '../types/response.type';
+import { User } from '../entities/user.entity';
+
+export const GetUserByIdDocs = {
+  get: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Get a user by ID' }),
+      ApiResponse({
+        status: 200,
+        description: 'User retrieved successfully',
+        type: () => ApiResponseType<User>,
+      }),
+      ApiNotFoundResponse({
+        description: 'User not found',
+      }),
+    ),
+};

--- a/src/modules/users/docs/update-user-by-id.docs.ts
+++ b/src/modules/users/docs/update-user-by-id.docs.ts
@@ -1,0 +1,27 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+} from '@nestjs/swagger';
+import { ApiResponse as ApiResponseType } from '../types/response.type';
+import { User } from '../entities/user.entity';
+
+export const UpdateUserByIdDocs = {
+  update: () =>
+    applyDecorators(
+      ApiOperation({ summary: 'Update a user by ID' }),
+      ApiResponse({
+        status: 200,
+        description: 'User updated successfully',
+        type: () => ApiResponseType<User>,
+      }),
+      ApiNotFoundResponse({
+        description: 'User not found',
+      }),
+      ApiBadRequestResponse({
+        description: 'Bad Request - Invalid or missing data',
+      }),
+    ),
+};

--- a/src/modules/users/dto/create-user.dto.ts
+++ b/src/modules/users/dto/create-user.dto.ts
@@ -1,3 +1,4 @@
+// src/users/dto/create-user.dto.ts
 import {
   IsEmail,
   IsEnum,
@@ -6,18 +7,36 @@ import {
   MinLength,
 } from 'class-validator';
 import { UserRole } from '../entities/user.enums';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateUserDto {
+  @ApiProperty({
+    description: 'Full name of the user',
+    example: 'John Doe',
+  })
   @IsString()
   @IsNotEmpty()
   full_name: string;
 
+  @ApiProperty({
+    description: 'Email address of the user',
+    example: 'john@example.com',
+  })
   @IsEmail()
   email: string;
 
+  @ApiProperty({
+    description: 'Password for the user account (minimum 6 characters)',
+    example: 'password123',
+  })
   @MinLength(6)
   password: string;
 
+  @ApiProperty({
+    description: 'Role of the user',
+    enum: UserRole,
+    example: UserRole.ADMIN,
+  })
   @IsEnum(UserRole)
   role: UserRole;
 }

--- a/src/modules/users/dto/update-user.dto.ts
+++ b/src/modules/users/dto/update-user.dto.ts
@@ -1,4 +1,58 @@
-import { PartialType } from '@nestjs/mapped-types';
+// src/users/dto/update-user.dto.ts
+import { PartialType, OmitType } from '@nestjs/mapped-types';
 import { CreateUserDto } from './create-user.dto';
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsEmail,
+  IsEnum,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+import { UserRole } from '../entities/user.enums';
 
-export class UpdateUserDto extends PartialType(CreateUserDto) {}
+// export class UpdateUserDto extends PartialType(
+//   OmitType(CreateUserDto, ['email', 'role'] as const),
+// ) {}
+
+export class UpdateUserDto extends PartialType(
+  OmitType(CreateUserDto, [] as const),
+) {
+  @ApiProperty({
+    description: 'Full name of the user (optional)',
+    example: 'Jane Doe',
+    required: false,
+  })
+  @IsString()
+  @IsOptional()
+  full_name?: string;
+
+  @ApiProperty({
+    description: 'Email address of the user (optional)',
+    example: 'jane@example.com',
+    required: false,
+  })
+  @IsEmail()
+  @IsOptional()
+  email?: string;
+
+  @ApiProperty({
+    description:
+      'Password for the user account (optional, minimum 6 characters if provided)',
+    example: 'newpassword123',
+    required: false,
+  })
+  @MinLength(6)
+  @IsOptional()
+  password?: string;
+
+  @ApiProperty({
+    description: 'Role of the user (optional)',
+    enum: UserRole,
+    example: UserRole.ADMIN,
+    required: false,
+  })
+  @IsEnum(UserRole)
+  @IsOptional()
+  role?: UserRole;
+}

--- a/src/modules/users/entities/user.entity.ts
+++ b/src/modules/users/entities/user.entity.ts
@@ -1,36 +1,62 @@
 import {
+  Column,
   Entity,
   PrimaryGeneratedColumn,
-  Column,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { UserRole } from './user.enums';
+import { ApiProperty } from '@nestjs/swagger';
 
 @Entity('users')
 export class User {
+  @ApiProperty({
+    description: 'Unique identifier for the user',
+    example: '1a2b3c4d',
+  })
   @PrimaryGeneratedColumn('uuid')
   id: string;
 
-  @Column({ length: 100 })
+  @ApiProperty({
+    description: 'Full name of the user',
+    example: 'John Doe',
+  })
+  @Column()
   full_name: string;
 
-  @Column({ unique: true, length: 100 })
+  @ApiProperty({
+    description: 'Email address of the user',
+    example: 'malach@salama.com',
+  })
+  @Column({ unique: true })
   email: string;
 
+  @ApiProperty({
+    description: 'Hashed password of the user',
+    example: '$2b$10$...',
+  })
   @Column()
   password: string;
 
-  @Column({
-    type: 'enum',
+  @ApiProperty({
+    description: 'Role of the user',
     enum: UserRole,
-    default: UserRole.CASHIER,
+    example: UserRole.ADMIN,
   })
+  @Column({ type: 'enum', enum: UserRole })
   role: UserRole;
 
+  @ApiProperty({
+    description: 'Timestamp when the user was created',
+    example: '2025-03-29T12:00:00.000Z',
+  })
   @CreateDateColumn()
   created_at: Date;
 
+  @ApiProperty({
+    description: 'Timestamp when the user was last updated',
+    example: '2025-03-29T12:00:00.000Z',
+  })
   @UpdateDateColumn()
   updated_at: Date;
 }

--- a/src/modules/users/types/response.type.ts
+++ b/src/modules/users/types/response.type.ts
@@ -1,4 +1,19 @@
-export interface ApiResponse<T> {
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ApiResponse<T> {
+  @ApiProperty({
+    description: 'Message describing the result of the operation',
+    example: 'User operation successful',
+  })
   message: string;
+
+  @ApiProperty({
+    description: 'Data returned by the operation',
+  })
   data: T;
+
+  constructor(response: { message: string; data: T }) {
+    this.message = response.message;
+    this.data = response.data;
+  }
 }

--- a/src/modules/users/users.controller.ts
+++ b/src/modules/users/users.controller.ts
@@ -6,33 +6,46 @@ import {
   Delete,
   Param,
   Body,
+  HttpCode,
 } from '@nestjs/common';
 import { UsersService } from './users.service';
-import { User } from './entities/user.entity';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
-import { ApiResponse } from './types/response.type'; // Import the response type
+import { ApiResponse } from './types/response.type';
+import { ApiTags } from '@nestjs/swagger';
+import { CreateUserDocs } from './docs/create-user.docs';
+import { GetAllUsersDocs } from './docs/get-all-users.docs';
+import { GetUserByIdDocs } from './docs/get-user-by-id.docs';
+import { UpdateUserByIdDocs } from './docs/update-user-by-id.docs';
+import { DeleteUserByIdDocs } from './docs/delete-user-by-id.docs';
+import { User } from './entities/user.entity';
 
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
   constructor(private readonly usersService: UsersService) {}
 
   @Post()
+  @HttpCode(201)
+  @CreateUserDocs.create()
   createUser(@Body() createUserDto: CreateUserDto): Promise<ApiResponse<User>> {
     return this.usersService.createUser(createUserDto);
   }
 
   @Get()
+  @GetAllUsersDocs.get()
   findAllUsers(): Promise<ApiResponse<User[]>> {
     return this.usersService.findAllUsers();
   }
 
   @Get(':id')
+  @GetUserByIdDocs.get()
   findUserById(@Param('id') id: string): Promise<ApiResponse<User>> {
     return this.usersService.findUserById(id);
   }
 
   @Patch(':id')
+  @UpdateUserByIdDocs.update()
   updateUser(
     @Param('id') id: string,
     @Body() updateUserDto: UpdateUserDto,
@@ -41,6 +54,7 @@ export class UsersController {
   }
 
   @Delete(':id')
+  @DeleteUserByIdDocs.delete()
   deleteUser(@Param('id') id: string): Promise<ApiResponse<boolean>> {
     return this.usersService.deleteUser(id);
   }

--- a/src/modules/users/users.service.spec.ts
+++ b/src/modules/users/users.service.spec.ts
@@ -13,7 +13,7 @@ const mockUser = {
   id: '1a2b3c4d',
   full_name: 'John Doe',
   email: 'johndoe@example.com',
-  password: 'hashedPassword123', // Hashed password
+  password: 'hashedPassword123',
   role: UserRole.ADMIN,
   created_at: new Date(),
   updated_at: new Date(),
@@ -158,8 +158,8 @@ describe('UsersService', () => {
       const updateUserDto: UpdateUserDto = { full_name: 'Jane Doe' };
       const updatedUser = { ...mockUser, ...updateUserDto };
 
-      repository.findOne.mockResolvedValueOnce(mockUser); // For findUserById
-      repository.save.mockResolvedValueOnce(updatedUser); // For save
+      repository.findOne.mockResolvedValueOnce(mockUser);
+      repository.save.mockResolvedValueOnce(updatedUser);
 
       const result = await service.updateUser('1a2b3c4d', updateUserDto);
 
@@ -173,6 +173,26 @@ describe('UsersService', () => {
       });
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(repository.save).toHaveBeenCalledWith(updatedUser);
+    });
+
+    it('should hash password if provided and update the user', async () => {
+      const updateUserDto: UpdateUserDto = { password: 'newpassword123' };
+      const updatedUser = { ...mockUser, password: 'hashedPassword123' };
+
+      repository.findOne.mockResolvedValueOnce(mockUser);
+      repository.save.mockResolvedValueOnce(updatedUser);
+
+      const result = await service.updateUser('1a2b3c4d', updateUserDto);
+
+      expect(result).toEqual({
+        message: 'User updated successfully',
+        data: updatedUser,
+      });
+      expect(bcrypt.hash).toHaveBeenCalledWith('newpassword123', 'salt');
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(repository.save).toHaveBeenCalledWith(
+        expect.objectContaining({ password: 'hashedPassword123' }),
+      );
     });
 
     it('should throw NotFoundException when updating a non-existent user', async () => {

--- a/src/modules/users/users.service.ts
+++ b/src/modules/users/users.service.ts
@@ -22,28 +22,28 @@ export class UsersService {
       password: hashedPassword,
     });
     const savedUser = await this.usersRepository.save(newUser);
-    return {
+    return new ApiResponse<User>({
       message: 'User created successfully',
       data: savedUser,
-    };
+    });
   }
 
   async findAllUsers(): Promise<ApiResponse<User[]>> {
     const users = await this.usersRepository.find();
-    return {
+    return new ApiResponse<User[]>({
       message:
         users.length > 0 ? 'Users retrieved successfully' : 'No users found',
       data: users,
-    };
+    });
   }
 
   async findUserById(id: string): Promise<ApiResponse<User>> {
     const user = await this.usersRepository.findOne({ where: { id } });
     if (!user) throw new NotFoundException(`User with ID ${id} not found`);
-    return {
+    return new ApiResponse<User>({
       message: 'User retrieved successfully',
       data: user,
-    };
+    });
   }
 
   async updateUser(
@@ -52,12 +52,19 @@ export class UsersService {
   ): Promise<ApiResponse<User>> {
     const userResponse = await this.findUserById(id);
     const user = userResponse.data;
+
+    // Hash the password if provided
+    if (updateUserDto.password) {
+      const salt = await bcrypt.genSalt();
+      updateUserDto.password = await bcrypt.hash(updateUserDto.password, salt);
+    }
+
     Object.assign(user, updateUserDto);
     const updatedUser = await this.usersRepository.save(user);
-    return {
+    return new ApiResponse<User>({
       message: 'User updated successfully',
       data: updatedUser,
-    };
+    });
   }
 
   async deleteUser(id: string): Promise<ApiResponse<boolean>> {
@@ -65,9 +72,9 @@ export class UsersService {
     if (result.affected === 0) {
       throw new NotFoundException(`User with ID ${id} not found`);
     }
-    return {
+    return new ApiResponse<boolean>({
       message: 'User deleted successfully',
       data: true,
-    };
+    });
   }
 }


### PR DESCRIPTION
This PR adds Swagger documentation for the users module, including:

- Swagger setup in main.ts
- Swagger decorators in src/users/docs
- Updated DTOs and entities with @ApiProperty for schema generation
- Fixed empty schema issue in Swagger UI