### PR TITLE
fix: Refactor AuthService to use ApiResponse, remove LoginResponseDto

### DIFF
--- a/src/modules/auth/auth.controller.ts
+++ b/src/modules/auth/auth.controller.ts
@@ -1,7 +1,7 @@
 import { Controller, Post, Body, HttpCode } from '@nestjs/common';
 import { AuthService } from './auth.service';
 import { LoginDto } from './dto/login.dto';
-import { LoginResponseDto } from './dto/login-response.dto';
+import { ApiResponse } from '../../shared/types/response.type';
 import { ApiTags } from '@nestjs/swagger';
 import { LoginDocs } from './docs/login.docs';
 
@@ -13,7 +13,9 @@ export class AuthController {
   @Post('login')
   @HttpCode(201)
   @LoginDocs.login()
-  async login(@Body() loginDto: LoginDto): Promise<LoginResponseDto> {
+  async login(
+    @Body() loginDto: LoginDto,
+  ): Promise<ApiResponse<{ access_token: string }>> {
     return this.authService.login(loginDto);
   }
 }

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -3,7 +3,7 @@ import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
 import * as bcrypt from 'bcrypt';
 import { LoginDto } from './dto/login.dto';
-import { LoginResponseDto } from './dto/login-response.dto';
+import { ApiResponse } from '../../shared/types/response.type';
 
 @Injectable()
 export class AuthService {
@@ -12,7 +12,9 @@ export class AuthService {
     private jwtService: JwtService,
   ) {}
 
-  async login(loginDto: LoginDto): Promise<LoginResponseDto> {
+  async login(
+    loginDto: LoginDto,
+  ): Promise<ApiResponse<{ access_token: string }>> {
     const userResponse = await this.usersService.findUserByEmail(
       loginDto.email,
     );
@@ -33,6 +35,9 @@ export class AuthService {
     const payload = { sub: user.id, email: user.email, role: user.role };
     const access_token = await this.jwtService.signAsync(payload);
 
-    return { access_token };
+    return new ApiResponse({
+      message: 'Login successful',
+      data: { access_token },
+    });
   }
 }

--- a/src/modules/auth/docs/login.docs.ts
+++ b/src/modules/auth/docs/login.docs.ts
@@ -4,7 +4,7 @@ import {
   ApiResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
-import { LoginResponseDto } from '../dto/login-response.dto';
+import { ApiResponse as ApiResponseType } from '../../../shared/types/response.type';
 
 export const LoginDocs = {
   login: () =>
@@ -13,7 +13,7 @@ export const LoginDocs = {
       ApiResponse({
         status: 201,
         description: 'User logged in successfully',
-        type: LoginResponseDto,
+        type: ApiResponseType,
       }),
       ApiUnauthorizedResponse({
         description: 'Unauthorized - Invalid credentials',

--- a/src/modules/auth/dto/login-response.dto.ts
+++ b/src/modules/auth/dto/login-response.dto.ts
@@ -1,9 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-
-export class LoginResponseDto {
-  @ApiProperty({
-    description: 'JWT access token',
-    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
-  })
-  access_token: string;
-}

--- a/src/modules/products/products.controller.ts
+++ b/src/modules/products/products.controller.ts
@@ -25,7 +25,7 @@ import { RolesGuard } from '../auth/guards/roles.guard';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { UserRole } from '../users/entities/user.enums';
 
-@ApiTags('products')
+@ApiTags('Products')
 @Controller('products')
 @ApiBearerAuth()
 export class ProductsController {

--- a/src/shared/types/response.type.ts
+++ b/src/shared/types/response.type.ts
@@ -3,7 +3,7 @@ import { ApiProperty } from '@nestjs/swagger';
 export class ApiResponse<T> {
   @ApiProperty({
     description: 'Message describing the result of the operation',
-    example: 'User operation successful',
+    example: 'Successful',
   })
   message: string;
 


### PR DESCRIPTION
- Refactor AuthService to use the generic ApiResponse<T> instead of the specific LoginResponseDto
- Delete the unneeded LoginResponseDto